### PR TITLE
fix: trust refork GitHub OIDC identity

### DIFF
--- a/.github/scripts/check-direct-aws-deploy.py
+++ b/.github/scripts/check-direct-aws-deploy.py
@@ -215,7 +215,9 @@ forbid(workflow, r"role-to-assume:\s*arn:aws:iam::\d{12}", "deployment workflow"
 for needle in (
     "https://token.actions.githubusercontent.com",
     "sts.amazonaws.com",
-    "repo:TotalLag/OpnForm:environment:opnform-prod",
+    "6938fd4d98bab03faadb97b34396831e3780aea1",
+    "cabd2a79a1076a31f21d253635cb039d4329a5e8",
+    "repo:TotalLag@1744428/OpnForm@1317796294:environment:opnform-prod",
     "ServerlessArtifactBucketName:",
     "UiShadowArtifactBucketName:",
     "BucketName: !Ref ServerlessArtifactBucketName",
@@ -509,7 +511,7 @@ else:
     if "Resource: !Sub 'arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/opnform-prod/*'" not in statement:
         failures.append("bootstrap template: ReadProductionStack resource scope changed")
 subjects = re.findall(r"token\.actions\.githubusercontent\.com:sub:\s*([^\s]+)", template)
-if subjects != ["repo:TotalLag/OpnForm:environment:opnform-prod"]:
+if subjects != ["repo:TotalLag@1744428/OpnForm@1317796294:environment:opnform-prod"]:
     failures.append("bootstrap template: OIDC subject must be exactly the opnform-prod environment subject")
 for policy in ("AdministratorAccess", "PowerUserAccess"):
     forbid(template, policy, "bootstrap template")

--- a/infra/aws/opnform-direct-aws-bootstrap.yml
+++ b/infra/aws/opnform-direct-aws-bootstrap.yml
@@ -18,6 +18,7 @@ Resources:
         - sts.amazonaws.com
       ThumbprintList:
         - 6938fd4d98bab03faadb97b34396831e3780aea1
+        - cabd2a79a1076a31f21d253635cb039d4329a5e8
 
   ServerlessArtifactBucket:
     Type: AWS::S3::Bucket
@@ -327,7 +328,7 @@ Resources:
             Condition:
               StringEquals:
                 token.actions.githubusercontent.com:aud: sts.amazonaws.com
-                token.actions.githubusercontent.com:sub: repo:TotalLag/OpnForm:environment:opnform-prod
+                token.actions.githubusercontent.com:sub: repo:TotalLag@1744428/OpnForm@1317796294:environment:opnform-prod
       Policies:
         - PolicyName: DeployOpnFormProductionStack
           PolicyDocument:


### PR DESCRIPTION
## Summary
- pin the GitHub deploy role to the refork ID-bound OIDC subject observed from a live token
- add the current ISRG Root X1 thumbprint while retaining the prior root
- update the deployment boundary validator to fail closed on both values

## Evidence
- `python3 .github/scripts/check-direct-aws-deploy.py`
- `aws cloudformation validate-template --template-body file://infra/aws/opnform-direct-aws-bootstrap.yml`
- workflow YAML parse
- Python compile
- `git diff --check`
- live UI workflow attempt 7 succeeded at `1738705f3664a48b95add83c78d88b6220d16bc2`

## Safety
The trust is narrowed to owner ID `1744428`, repository ID `1317796294`, and environment `opnform-prod`; no branch wildcard or repository-name-only fallback is retained.