### PR TITLE
TAG: apply OpnForm AWS cost allocation tags

### DIFF
--- a/.github/scripts/check-direct-aws-deploy.py
+++ b/.github/scripts/check-direct-aws-deploy.py
@@ -61,6 +61,47 @@ def as_list(value):
     return [value]
 
 
+def require_exact_resource_tags(template_data, expected_by_resource, label):
+    resources = template_data.get("Resources", {}) if isinstance(template_data, dict) else {}
+    if not isinstance(resources, dict):
+        failures.append(f"{label}: Resources must be a mapping")
+        return
+
+    for resource_name in expected_by_resource:
+        if resource_name not in resources:
+            failures.append(f"{label}: missing taggable resource {resource_name}")
+
+    for resource_name, resource in resources.items():
+        if not isinstance(resource, dict):
+            failures.append(f"{label}: {resource_name} must be a mapping")
+            continue
+        properties = resource.get("Properties", {})
+        if "Tags" in resource:
+            failures.append(f"{label}: {resource_name} Tags must be under Properties")
+        if resource_name not in expected_by_resource:
+            if isinstance(properties, dict) and "Tags" in properties:
+                failures.append(f"{label}: {resource_name} must not define Tags")
+            continue
+        if not isinstance(properties, dict):
+            failures.append(f"{label}: {resource_name} Properties must be a mapping")
+            continue
+        tags = properties.get("Tags")
+        if not isinstance(tags, list):
+            failures.append(f"{label}: {resource_name} Tags must be a list under Properties")
+            continue
+        tag_map = {}
+        for tag in tags:
+            if not isinstance(tag, dict) or set(tag) != {"Key", "Value"}:
+                failures.append(f"{label}: {resource_name} tags must contain only Key and Value")
+                continue
+            key = tag["Key"]
+            if key in tag_map:
+                failures.append(f"{label}: {resource_name} has duplicate tag {key!r}")
+            tag_map[key] = tag["Value"]
+        if tag_map != expected_by_resource[resource_name]:
+            failures.append(f"{label}: {resource_name} tags must be exactly {expected_by_resource[resource_name]}")
+
+
 def role_statements(template_data, role_name: str):
     if not isinstance(template_data, dict):
         return []
@@ -144,10 +185,14 @@ for needle in (
     require(serverless, needle, "serverless configuration")
 forbid(serverless, r"/laravel/", "serverless configuration")
 if isinstance(serverless_data, dict):
-    if serverless_data.get("provider", {}).get("stackName") != "opnform-prod":
+    provider = serverless_data.get("provider", {})
+    if provider.get("stackName") != "opnform-prod":
         failures.append("serverless configuration: stackName must be opnform-prod")
     if serverless_data.get("params", {}).get("default", {}).get("ssmPrefix") != "/opnform/prod":
         failures.append("serverless configuration: ssmPrefix must be /opnform/prod")
+    for field in ("tags", "stackTags"):
+        if provider.get(field) != {"Project": "OpnForm"}:
+            failures.append(f"serverless configuration: provider.{field} must be exactly Project=OpnForm")
 forbid(serverless, r"\bus-(?!east-1\b)[a-z]+-\d+\b", "serverless configuration")
 
 if package.get("devDependencies", {}).get("serverless") != "3.40.0":
@@ -176,6 +221,20 @@ if isinstance(workflow_data, dict):
         failures.append("deployment workflow: UI shadow job must be separately conditional")
 else:
     failures.append("deployment workflow: YAML root must be a mapping")
+
+if isinstance(workflow_data, dict):
+    shadow_steps = workflow_data.get("jobs", {}).get("shadow", {}).get("steps", [])
+    change_set_steps = [
+        step for step in shadow_steps
+        if isinstance(step, dict) and step.get("name") == "Create and execute the guarded branch UI change set"
+    ]
+    if len(change_set_steps) != 1:
+        failures.append("deployment workflow: UI change-set step must occur exactly once")
+    else:
+        change_set_run = change_set_steps[0].get("run")
+        tag_arguments = re.findall(r"(?:^|\s)--tags\s+([^\s\\]+)", change_set_run if isinstance(change_set_run, str) else "")
+        if tag_arguments != ["Key=Project,Value=OpnForm"]:
+            failures.append("deployment workflow: UI change set must use exactly --tags Key=Project,Value=OpnForm")
 for trigger in ("push", "schedule", "pull_request", "workflow_run", "workflow_call"):
     forbid(workflow, rf"^\s*{trigger}:", "deployment workflow")
 for needle in (
@@ -240,6 +299,17 @@ for needle in (
     "iam:CreateRole",
 ):
     require(template, needle, "bootstrap template")
+require_exact_resource_tags(
+    template_data,
+    {
+        "GitHubActionsOidcProvider": {"Project": "OpnForm"},
+        "ServerlessArtifactBucket": {"Project": "OpnForm"},
+        "UiShadowArtifactBucket": {"Project": "OpnForm"},
+        "OpnFormCloudFormationExecutionRole": {"Project": "OpnForm"},
+        "OpnFormGitHubDeployRole": {"Project": "OpnForm"},
+    },
+    "bootstrap template",
+)
 execution_statements = role_statements(template_data, "OpnFormCloudFormationExecutionRole")
 deploy_statements = role_statements(template_data, "OpnFormGitHubDeployRole")
 all_iam_role_policy_statements = iam_role_policy_statements(template_data)
@@ -247,6 +317,33 @@ if not execution_statements:
     failures.append("bootstrap template: CloudFormation execution role policy statements are missing")
 if not deploy_statements:
     failures.append("bootstrap template: GitHub deploy role policy statements are missing")
+
+handler_tag_statements_expected = {
+    "ManageProductionSchedule": (
+        ["events:DeleteRule", "events:DescribeRule", "events:ListTagsForResource", "events:ListTargetsByRule", "events:PutRule", "events:PutTargets", "events:RemoveTargets", "events:TagResource", "events:UntagResource"],
+        "arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/opnform-prod-*",
+    ),
+    "ManageProductionLogGroups": (
+        ["logs:DeleteLogGroup", "logs:ListTagsForResource", "logs:PutRetentionPolicy", "logs:TagResource", "logs:UntagResource"],
+        "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/opnform-prod-*",
+    ),
+    "ManageUiShadowPublicBuckets": (
+        ["s3:CreateBucket", "s3:DeleteBucket", "s3:DeleteBucketPolicy", "s3:GetBucketLocation", "s3:GetBucketPolicy", "s3:GetBucketPublicAccessBlock", "s3:GetBucketTagging", "s3:ListTagsForResource", "s3:PutEncryptionConfiguration", "s3:PutBucketOwnershipControls", "s3:PutBucketPolicy", "s3:PutBucketPublicAccessBlock", "s3:PutBucketTagging", "s3:TagResource", "s3:UntagResource"],
+        "arn:aws:s3:::opnform-ui-shadow-*-assets",
+    ),
+    "ManageUiShadowLogs": (
+        ["logs:CreateLogGroup", "logs:DeleteLogGroup", "logs:ListTagsForResource", "logs:PutRetentionPolicy", "logs:TagResource", "logs:UntagResource"],
+        "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/opnform-ui-shadow-*",
+    ),
+}
+for sid, (expected_actions, expected_resource) in handler_tag_statements_expected.items():
+    statements = [statement for statement in execution_statements if statement.get("Sid") == sid]
+    if len(statements) != 1:
+        failures.append(f"bootstrap template: exactly one {sid} statement is required")
+        continue
+    statement = statements[0]
+    if as_list(statement.get("Action")) != expected_actions or statement.get("Resource") != expected_resource:
+        failures.append(f"bootstrap template: {sid} handler tag actions or resource scope changed")
 
 artisan_invoke_statements = [
     statement for statement in deploy_statements
@@ -270,9 +367,14 @@ for statement in deploy_statements:
         failures.append("bootstrap template: lambda invocation must stay in InvokeOnlyProductionArtisan")
 
 event_source_mapping_resource = "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:event-source-mapping:*"
-event_source_mapping_actions_expected = [
-    "lambda:CreateEventSourceMapping",
+event_source_mapping_actions_expected = ["lambda:CreateEventSourceMapping"]
+event_source_mapping_management_actions_expected = [
+    "lambda:DeleteEventSourceMapping",
+    "lambda:GetEventSourceMapping",
+    "lambda:ListTags",
     "lambda:TagResource",
+    "lambda:UntagResource",
+    "lambda:UpdateEventSourceMapping",
 ]
 event_source_mapping_statements = [
     (role_name, policy_name, statement)
@@ -301,7 +403,7 @@ else:
         or len(actions) != len(set(actions))
     ):
         failures.append(
-            "bootstrap template: CreateProductionEventSourceMappings must list exactly lambda:CreateEventSourceMapping and lambda:TagResource"
+            "bootstrap template: CreateProductionEventSourceMappings must allow only lambda:CreateEventSourceMapping"
         )
     if statement.get("Resource") != event_source_mapping_resource:
         failures.append(
@@ -311,6 +413,21 @@ else:
         failures.append(
             "bootstrap template: CreateProductionEventSourceMappings must not add conditions or other fields"
         )
+
+mapping_management_statements = [
+    statement for statement in execution_statements
+    if statement.get("Sid") == "ManageProductionEventSourceMappings"
+]
+if len(mapping_management_statements) != 1:
+    failures.append("bootstrap template: exactly one ManageProductionEventSourceMappings statement is required")
+else:
+    statement = mapping_management_statements[0]
+    if as_list(statement.get("Action")) != event_source_mapping_management_actions_expected:
+        failures.append("bootstrap template: ManageProductionEventSourceMappings must contain the exact mapping lifecycle and tag actions")
+    if statement.get("Resource") != event_source_mapping_resource:
+        failures.append("bootstrap template: ManageProductionEventSourceMappings must use the exact regional event-source-mapping ARN")
+    if set(statement) != {"Sid", "Effect", "Action", "Resource"}:
+        failures.append("bootstrap template: ManageProductionEventSourceMappings must not add conditions or other fields")
 
 event_source_mapping_actions = [
     (role_name, policy_name, statement)
@@ -331,35 +448,46 @@ elif (
         "bootstrap template: lambda:CreateEventSourceMapping must stay in CreateProductionEventSourceMappings in the CloudFormation execution role policy"
     )
 
-event_source_mapping_tag_actions = [
-    (role_name, policy_name, statement)
-    for role_name, policy_name, statement in all_iam_role_policy_statements
-    if "lambda:TagResource" in as_list(statement.get("Action"))
-    and statement.get("Resource") == event_source_mapping_resource
-]
-if len(event_source_mapping_tag_actions) != 1:
-    failures.append(
-        "bootstrap template: mapping lambda:TagResource must occur only in CreateProductionEventSourceMappings"
-    )
-elif (
-    event_source_mapping_tag_actions[0][:2]
-    != ("OpnFormCloudFormationExecutionRole", "OpnFormProductionStack")
-    or event_source_mapping_tag_actions[0][2].get("Sid")
-    != "CreateProductionEventSourceMappings"
-):
-    failures.append(
-        "bootstrap template: mapping lambda:TagResource must stay in CreateProductionEventSourceMappings in the CloudFormation execution role policy"
-    )
+for mapping_action in ("lambda:ListTags", "lambda:TagResource", "lambda:UntagResource"):
+    mapping_action_statements = [
+        (role_name, policy_name, statement)
+        for role_name, policy_name, statement in all_iam_role_policy_statements
+        if mapping_action in as_list(statement.get("Action"))
+        and statement.get("Resource") == event_source_mapping_resource
+    ]
+    if len(mapping_action_statements) != 1:
+        failures.append(
+            f"bootstrap template: mapping {mapping_action} must occur only in ManageProductionEventSourceMappings"
+        )
+    elif (
+        mapping_action_statements[0][:2]
+        != ("OpnFormCloudFormationExecutionRole", "OpnFormProductionStack")
+        or mapping_action_statements[0][2].get("Sid")
+        != "ManageProductionEventSourceMappings"
+    ):
+        failures.append(
+            f"bootstrap template: mapping {mapping_action} must stay in ManageProductionEventSourceMappings in the CloudFormation execution role policy"
+        )
 
 for role_name, policy_name, statement in all_iam_role_policy_statements:
-    if "lambda:TagResource" not in as_list(statement.get("Action")):
+    if "lambda:ListTags" in as_list(statement.get("Action")) and (
+        (role_name, policy_name, statement.get("Sid"), statement.get("Resource"))
+        != (
+            "OpnFormCloudFormationExecutionRole",
+            "OpnFormProductionStack",
+            "ManageProductionEventSourceMappings",
+            event_source_mapping_resource,
+        )
+    ):
+        failures.append("bootstrap template: lambda:ListTags must stay on exact production event-source mappings")
+    if not any(action in {"lambda:TagResource", "lambda:UntagResource"} for action in as_list(statement.get("Action"))):
         continue
     is_mapping_tag_statement = (
         (role_name, policy_name, statement.get("Sid"))
         == (
             "OpnFormCloudFormationExecutionRole",
             "OpnFormProductionStack",
-            "CreateProductionEventSourceMappings",
+            "ManageProductionEventSourceMappings",
         )
         and statement.get("Resource") == event_source_mapping_resource
     )
@@ -385,7 +513,7 @@ for role_name, policy_name, statement in all_iam_role_policy_statements:
     )
     if not is_mapping_tag_statement and not is_function_tag_statement and not is_ui_shadow_function_tag_statement:
         failures.append(
-            "bootstrap template: lambda:TagResource may only tag approved production functions, UI shadow functions, or event-source mappings"
+            "bootstrap template: Lambda tag updates may only target approved production functions, UI shadow functions, or event-source mappings"
         )
 
 expected_http_api_actions = {
@@ -395,6 +523,7 @@ expected_http_api_actions = {
     "apigateway:POST",
     "apigateway:PUT",
     "apigateway:TagResource",
+    "apigateway:UntagResource",
 }
 manage_http_api = [
     statement for statement in execution_statements if statement.get("Sid") == "ManageHttpApi"
@@ -406,7 +535,7 @@ else:
     actions = as_list(statement.get("Action"))
     if set(actions) != expected_http_api_actions or len(actions) != len(expected_http_api_actions):
         failures.append(
-            "bootstrap template: ManageHttpApi must enumerate only the approved HTTP API actions including apigateway:TagResource"
+            "bootstrap template: ManageHttpApi must enumerate only the approved HTTP API actions including stage tag updates"
         )
     if statement.get("Resource") != "*":
         failures.append("bootstrap template: ManageHttpApi resource scope must remain '*' for HTTP API control plane")
@@ -422,6 +551,31 @@ for statement in deploy_statements:
     ]
     if api_actions:
         failures.append("bootstrap template: GitHub deploy role must not grant API Gateway actions")
+
+expected_ui_alarm_actions = [
+    "cloudwatch:DeleteAlarms",
+    "cloudwatch:DescribeAlarms",
+    "cloudwatch:ListTagsForResource",
+    "cloudwatch:PutMetricAlarm",
+    "cloudwatch:TagResource",
+    "cloudwatch:UntagResource",
+]
+ui_alarm_statements = [
+    statement for statement in execution_statements
+    if statement.get("Sid") == "ManageUiShadowAlarms"
+]
+if len(ui_alarm_statements) != 1:
+    failures.append("bootstrap template: exactly one ManageUiShadowAlarms statement is required")
+else:
+    statement = ui_alarm_statements[0]
+    if as_list(statement.get("Action")) != expected_ui_alarm_actions:
+        failures.append("bootstrap template: ManageUiShadowAlarms must use only the approved alarm actions")
+    if statement.get("Resource") != "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:opnform-ui-shadow-*":
+        failures.append("bootstrap template: ManageUiShadowAlarms resource scope changed")
+for statement in execution_statements:
+    if any(action in {"cloudwatch:TagResource", "cloudwatch:UntagResource"} for action in as_list(statement.get("Action"))):
+        if statement.get("Sid") != "ManageUiShadowAlarms":
+            failures.append("bootstrap template: CloudWatch tag actions must stay in ManageUiShadowAlarms")
 
 bref_external_account_id = "534081306603"
 bref_layer_version_arns = {

--- a/.github/workflows/deploy-api-direct-aws.yml
+++ b/.github/workflows/deploy-api-direct-aws.yml
@@ -255,6 +255,7 @@ jobs:
             --change-set-type "$change_set_type" \
             --template-body file://client/infra/aws/ui-shadow.yml \
             --capabilities CAPABILITY_NAMED_IAM \
+            --tags Key=Project,Value=OpnForm \
             --role-arn "$AWS_CFN_ROLE_ARN" \
             --parameters \
               ParameterKey=ShadowPrefix,ParameterValue="$shadow" \

--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -10,6 +10,10 @@ provider:
   stackName: opnform-prod
   deploymentMethod: changesets
   region: us-east-1
+  tags:
+    Project: OpnForm
+  stackTags:
+    Project: OpnForm
   deploymentBucket:
     name: ${env:AWS_API_DEPLOYMENT_BUCKET}
   httpApi:

--- a/client/infra/aws/check-ui-shadow.py
+++ b/client/infra/aws/check-ui-shadow.py
@@ -39,14 +39,26 @@ ALARM_ARN = "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:opnform-u
 EXECUTION_UI_STATEMENTS = {
     "ReadUiShadowArtifacts": (["s3:GetBucketLocation", "s3:ListBucket"], "UiShadowArtifactBucket.Arn"),
     "ReadUiShadowArtifactObjects": (["s3:GetObject", "s3:GetObjectVersion"], "${UiShadowArtifactBucket.Arn}/opnform-ui-shadow-*/*"),
-    "ManageUiShadowPublicBuckets": (["s3:CreateBucket", "s3:DeleteBucket", "s3:DeleteBucketPolicy", "s3:GetBucketLocation", "s3:GetBucketPolicy", "s3:GetBucketPublicAccessBlock", "s3:PutEncryptionConfiguration", "s3:PutBucketOwnershipControls", "s3:PutBucketPolicy", "s3:PutBucketPublicAccessBlock", "s3:PutBucketTagging"], "arn:aws:s3:::opnform-ui-shadow-*-assets"),
+    "ManageUiShadowPublicBuckets": (["s3:CreateBucket", "s3:DeleteBucket", "s3:DeleteBucketPolicy", "s3:GetBucketLocation", "s3:GetBucketPolicy", "s3:GetBucketPublicAccessBlock", "s3:GetBucketTagging", "s3:ListTagsForResource", "s3:PutEncryptionConfiguration", "s3:PutBucketOwnershipControls", "s3:PutBucketPolicy", "s3:PutBucketPublicAccessBlock", "s3:PutBucketTagging", "s3:TagResource", "s3:UntagResource"], "arn:aws:s3:::opnform-ui-shadow-*-assets"),
     "ManageUiShadowFunctions": (["lambda:AddPermission", "lambda:CreateFunction", "lambda:CreateFunctionUrlConfig", "lambda:DeleteFunction", "lambda:DeleteFunctionUrlConfig", "lambda:GetFunction", "lambda:GetFunctionConfiguration", "lambda:GetFunctionUrlConfig", "lambda:GetPolicy", "lambda:RemovePermission", "lambda:TagResource", "lambda:UntagResource", "lambda:UpdateFunctionCode", "lambda:UpdateFunctionConfiguration", "lambda:UpdateFunctionUrlConfig"], "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:opnform-ui-shadow-*"),
-    "ManageUiShadowLogs": (["logs:CreateLogGroup", "logs:DeleteLogGroup", "logs:PutRetentionPolicy", "logs:TagResource", "logs:UntagResource"], "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/opnform-ui-shadow-*"),
+    "ManageUiShadowLogs": (["logs:CreateLogGroup", "logs:DeleteLogGroup", "logs:ListTagsForResource", "logs:PutRetentionPolicy", "logs:TagResource", "logs:UntagResource"], "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/opnform-ui-shadow-*"),
     "ManageUiShadowLambdaRole": (["iam:CreateRole", "iam:DeleteRole", "iam:DeleteRolePolicy", "iam:GetRole", "iam:PutRolePolicy", "iam:TagRole", "iam:UntagRole"], "arn:aws:iam::${AWS::AccountId}:role/opnform-ui-shadow-*-lambda-role"),
     "PassOnlyUiShadowLambdaRole": (["iam:PassRole"], "arn:aws:iam::${AWS::AccountId}:role/opnform-ui-shadow-*-lambda-role"),
     "ManageUiShadowCloudFront": (["cloudfront:CreateCachePolicy", "cloudfront:CreateDistribution", "cloudfront:CreateDistributionWithTags", "cloudfront:CreateFunction", "cloudfront:CreateOriginAccessControl", "cloudfront:CreateOriginRequestPolicy", "cloudfront:DeleteCachePolicy", "cloudfront:DeleteDistribution", "cloudfront:DeleteFunction", "cloudfront:DeleteOriginAccessControl", "cloudfront:DeleteOriginRequestPolicy", "cloudfront:DescribeFunction", "cloudfront:GetCachePolicy", "cloudfront:GetDistribution", "cloudfront:GetDistributionConfig", "cloudfront:GetFunction", "cloudfront:GetOriginAccessControl", "cloudfront:GetOriginRequestPolicy", "cloudfront:ListTagsForResource", "cloudfront:PublishFunction", "cloudfront:TagResource", "cloudfront:UntagResource", "cloudfront:UpdateCachePolicy", "cloudfront:UpdateDistribution", "cloudfront:UpdateFunction", "cloudfront:UpdateOriginAccessControl", "cloudfront:UpdateOriginRequestPolicy"], "*"),
-    "ManageUiShadowAlarms": (["cloudwatch:DeleteAlarms", "cloudwatch:PutMetricAlarm"], ALARM_ARN),
+    "ManageUiShadowAlarms": (["cloudwatch:DeleteAlarms", "cloudwatch:DescribeAlarms", "cloudwatch:ListTagsForResource", "cloudwatch:PutMetricAlarm", "cloudwatch:TagResource", "cloudwatch:UntagResource"], ALARM_ARN),
 }
+UI_RESOURCE_TAGS = {
+    "PublicAssetsBucket": {"Project": "OpnForm", "opnform:scope": "ui-shadow", "opnform:prefix": "ShadowPrefix"},
+    "NuxtLambdaLogGroup": {"Project": "OpnForm"},
+    "NuxtLambdaRole": {"Project": "OpnForm"},
+    "NuxtLambda": {"Project": "OpnForm", "opnform:scope": "ui-shadow", "opnform:prefix": "ShadowPrefix"},
+    "ViewerHostAndApiRewrite": {"Project": "OpnForm"},
+    "Distribution": {"Project": "OpnForm", "opnform:scope": "ui-shadow", "opnform:prefix": "ShadowPrefix"},
+    "LambdaErrorsAlarm": {"Project": "OpnForm"},
+    "LambdaThrottlesAlarm": {"Project": "OpnForm"},
+    "LambdaDurationAlarm": {"Project": "OpnForm"},
+}
+
 DEPLOY_UI_STATEMENTS = {
     "UploadUiShadowLambdaArtifacts": (["s3:AbortMultipartUpload", "s3:DeleteObject", "s3:GetObject", "s3:ListMultipartUploadParts", "s3:PutObject"], "${UiShadowArtifactBucket.Arn}/opnform-ui-shadow-*/*"),
     "ListUiShadowArtifactBucket": (["s3:GetBucketLocation", "s3:ListBucket", "s3:ListBucketMultipartUploads"], "UiShadowArtifactBucket.Arn"),
@@ -77,6 +89,47 @@ def parse_yaml(source: str, content: str, failures: list[str]) -> dict[str, Any]
     except Exception as error:
         failures.append(f"{source}: invalid YAML: {error}")
     return {}
+
+
+def require_exact_ui_resource_tags(resources: Any, failures: list[str]) -> None:
+    if not isinstance(resources, dict):
+        failures.append("template: Resources must be a mapping")
+        return
+
+    for resource_name, expected_tags in UI_RESOURCE_TAGS.items():
+        resource = resources.get(resource_name)
+        if not isinstance(resource, dict):
+            failures.append(f"template: missing taggable resource {resource_name}")
+            continue
+        if "Tags" in resource:
+            failures.append(f"template: {resource_name} Tags must be under Properties")
+        properties = resource.get("Properties")
+        if not isinstance(properties, dict):
+            failures.append(f"template: {resource_name} Properties must be a mapping")
+            continue
+        tags = properties.get("Tags")
+        if not isinstance(tags, list):
+            failures.append(f"template: {resource_name} Tags must be a list under Properties")
+            continue
+        tag_map: dict[Any, Any] = {}
+        for tag in tags:
+            if not isinstance(tag, dict) or set(tag) != {"Key", "Value"}:
+                failures.append(f"template: {resource_name} tags must contain only Key and Value")
+                continue
+            key = tag["Key"]
+            if key in tag_map:
+                failures.append(f"template: {resource_name} has duplicate tag {key!r}")
+            tag_map[key] = tag["Value"]
+        if tag_map != expected_tags:
+            failures.append(f"template: {resource_name} tags must be exactly {expected_tags}")
+
+    for resource_name, resource in resources.items():
+        if not isinstance(resource, dict):
+            continue
+        if "Tags" in resource:
+            failures.append(f"template: {resource_name} Tags must be under Properties")
+        if resource_name not in UI_RESOURCE_TAGS and isinstance(resource.get("Properties"), dict) and "Tags" in resource["Properties"]:
+            failures.append(f"template: unsupported resource {resource_name} must not define Tags")
 
 
 def role_statements(data: dict[str, Any], role_name: str) -> list[dict[str, Any]]:
@@ -143,6 +196,7 @@ def validate(sources: dict[str, str]) -> list[str]:
         forbid(source, r"\b[a-z0-9]{10}\.execute-api\.us-east-1\.amazonaws\.com\b")
 
     resources = template_data.get("Resources", {})
+    require_exact_ui_resource_tags(resources, failures)
     distribution = resources.get("Distribution", {}) if isinstance(resources, dict) else {}
     distribution_properties = distribution.get("Properties", {}) if isinstance(distribution, dict) else {}
     if not isinstance(distribution_properties, dict) or "Tags" not in distribution_properties or "Tags" in distribution:
@@ -254,6 +308,18 @@ def validate(sources: dict[str, str]) -> list[str]:
     if not isinstance(workflow_data, dict) or set(workflow_data.get("jobs", {})) != {"deploy", "shadow"}:
         failures.append("workflow: must retain API and add only the conditional shadow job")
     shadow_workflow = workflow[workflow.index("  shadow:"):] if "  shadow:" in workflow else ""
+    shadow_steps = workflow_data.get("jobs", {}).get("shadow", {}).get("steps", []) if isinstance(workflow_data, dict) else []
+    change_set_steps = [
+        step for step in shadow_steps
+        if isinstance(step, dict) and step.get("name") == "Create and execute the guarded branch UI change set"
+    ]
+    if len(change_set_steps) != 1:
+        failures.append("workflow: UI change-set step must occur exactly once")
+    else:
+        change_set_run = change_set_steps[0].get("run")
+        tag_arguments = re.findall(r"(?:^|\s)--tags\s+([^\s\\]+)", change_set_run if isinstance(change_set_run, str) else "")
+        if tag_arguments != ["Key=Project,Value=OpnForm"]:
+            failures.append("workflow: UI change set must use exactly --tags Key=Project,Value=OpnForm")
     revision_guard = '[[ "$GITHUB_SHA" =~ ^[a-f0-9]{40}$ ]]'
     artifact_derivation = 'artifact_key="${shadow}/${GITHUB_SHA}/lambda.zip"'
     artifact_output = "printf 'artifact_key=%s\\n' \"$artifact_key\" >> \"$GITHUB_OUTPUT\""
@@ -450,12 +516,18 @@ def self_test(sources: dict[str, str]) -> list[str]:
     cases = [
         ("bootstrap", "s3:PutEncryptionConfiguration", "s3:PutBucketEncryption"),
         ("bootstrap", "s3:PutEncryptionConfiguration", "s3:*"),
+        ("bootstrap", "s3:GetBucketTagging", "s3:GetBucketAcl"),
+        ("bootstrap", "Sid: ManageUiShadowLogs\n                Effect: Allow\n                Action:\n                  - logs:CreateLogGroup\n                  - logs:DeleteLogGroup\n                  - logs:ListTagsForResource", "Sid: ManageUiShadowLogs\n                Effect: Allow\n                Action:\n                  - logs:CreateLogGroup\n                  - logs:DeleteLogGroup\n                  - logs:ListTagsForLogGroup"),
+        ("bootstrap", "cloudwatch:ListTagsForResource", "cloudwatch:ListTagsForAlarm"),
         ("bootstrap", "cloudfront:ListTagsForResource\n", ""),
         ("bootstrap", "Resource: arn:aws:s3:::opnform-ui-shadow-*-assets", "Resource: arn:aws:s3:::opnform-ui-shadow-*"),
         ("bootstrap", "Sid: ReadUiShadowArtifacts\n                Effect: Allow\n                Action:\n                  - s3:GetBucketLocation\n                  - s3:ListBucket", "Sid: ReadUiShadowArtifacts\n                Effect: Allow\n                Action:\n                  - s3:GetBucketLocation\n                  - s3:ListBucket\n                  - ec2:RunInstances"),
         ("bootstrap", "Resource: !Sub 'arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:opnform-ui-shadow-*'", "Resource:\n                  - !Sub 'arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:opnform-ui-shadow-*'\n                  - !Sub 'arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:unrelated'"),
         ("bootstrap", "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:opnform-ui-shadow-*", "arn:aws:lambda:${AWS::Region}:*:function:opnform-ui-shadow-*"),
         ("bootstrap", "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:opnform-ui-shadow-*", "arn:aws:lambda:us-*-1:${AWS::AccountId}:function:opnform-ui-shadow-*"),
+        ("template", "Key: Project\n          Value: OpnForm", "Key: CostCenter\n          Value: OpnForm"),
+        ("template", "Key: Project\n          Value: OpnForm", "Key: Project\n          Value: Other"),
+        ("template", "    Type: AWS::CloudFront::OriginAccessControl\n    Properties:", "    Type: AWS::CloudFront::OriginAccessControl\n    Properties:\n      Tags:\n        - Key: Project\n          Value: OpnForm"),
         ("template", "Service: cloudfront.amazonaws.com", "Principal: '*'"),
         ("template", "AuthType: AWS_IAM", "AuthType: NONE"),
         ("template", "BucketOwnerEnforced", "WebsiteConfiguration"),
@@ -494,6 +566,8 @@ def self_test(sources: dict[str, str]) -> list[str]:
         ("smoke", "console.log('smoke_phase=archive_extracted')", "console.log('smoke_phase=archive_ready')"),
         ("smoke", "console.log('smoke_phase=handler_imported')", "console.log('smoke_phase=handler_ready')"),
         ("smoke", "console.log('smoke_phase=handler_responded')", "console.log('smoke_phase=response_ready')"),
+        ("workflow", "--tags Key=Project,Value=OpnForm \\\n", ""),
+        ("workflow", "--tags Key=Project,Value=OpnForm", "--tags Key=Project,Value=Other"),
         ("workflow", "NODE_OPTIONS='--max-old-space-size=8192' NUXT_PRIVATE_API_BASE=\"https://$AWS_API_ORIGIN_DOMAIN\" NUXT_PUBLIC_API_BASE=/api /usr/bin/time -v npm run smoke:aws-lambda 2> .aws-shadow/smoke-time.txt", "NODE_OPTIONS='--max-old-space-size=16384' NUXT_PRIVATE_API_BASE=\"https://$AWS_API_ORIGIN_DOMAIN\" NUXT_PUBLIC_API_BASE=/api /usr/bin/time -v npm run smoke:aws-lambda 2> .aws-shadow/smoke-time.txt"),
         ("workflow", "AWS_API_ORIGIN_DOMAIN: ${{ secrets.AWS_API_ORIGIN_DOMAIN }}", ""),
         ("workflow", "NUXT_PRIVATE_API_BASE=\"https://$AWS_API_ORIGIN_DOMAIN\" ", ""),

--- a/client/infra/aws/ui-shadow.yml
+++ b/client/infra/aws/ui-shadow.yml
@@ -36,6 +36,8 @@ Resources:
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
       Tags:
+        - Key: Project
+          Value: OpnForm
         - Key: opnform:scope
           Value: ui-shadow
         - Key: opnform:prefix
@@ -46,11 +48,17 @@ Resources:
     Properties:
       LogGroupName: !Sub '/aws/lambda/${ShadowPrefix}-ssr'
       RetentionInDays: 14
+      Tags:
+        - Key: Project
+          Value: OpnForm
 
   NuxtLambdaRole:
     Type: AWS::IAM::Role
     Properties:
       RoleName: !Sub '${ShadowPrefix}-lambda-role'
+      Tags:
+        - Key: Project
+          Value: OpnForm
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -89,6 +97,8 @@ Resources:
           NUXT_PUBLIC_API_BASE: /api
           NUXT_PRIVATE_API_BASE: !Sub 'https://${ApiOriginDomain}'
       Tags:
+        - Key: Project
+          Value: OpnForm
         - Key: opnform:scope
           Value: ui-shadow
         - Key: opnform:prefix
@@ -180,6 +190,9 @@ Resources:
       FunctionConfig:
         Comment: Overwrite trusted viewer and forwarded hosts, then strip one API prefix.
         Runtime: cloudfront-js-2.0
+      Tags:
+        - Key: Project
+          Value: OpnForm
       FunctionCode: |
         function handler(event) {
           var request = event.request;
@@ -329,6 +342,8 @@ Resources:
             CachedMethods: [GET, HEAD]
             CachePolicyId: !Ref NoSharedCachePolicy
       Tags:
+        - Key: Project
+          Value: OpnForm
         - Key: opnform:scope
           Value: ui-shadow
         - Key: opnform:prefix
@@ -374,6 +389,9 @@ Resources:
     Properties:
       AlarmName: !Sub '${ShadowPrefix}-lambda-errors'
       AlarmDescription: Shadow SSR has one or more Lambda errors in five minutes.
+      Tags:
+        - Key: Project
+          Value: OpnForm
       Namespace: AWS/Lambda
       MetricName: Errors
       Statistic: Sum
@@ -391,6 +409,9 @@ Resources:
     Properties:
       AlarmName: !Sub '${ShadowPrefix}-lambda-throttles'
       AlarmDescription: Shadow SSR has one or more throttles in five minutes.
+      Tags:
+        - Key: Project
+          Value: OpnForm
       Namespace: AWS/Lambda
       MetricName: Throttles
       Statistic: Sum
@@ -408,6 +429,9 @@ Resources:
     Properties:
       AlarmName: !Sub '${ShadowPrefix}-lambda-duration'
       AlarmDescription: Shadow SSR p99 duration exceeds 20 seconds.
+      Tags:
+        - Key: Project
+          Value: OpnForm
       Namespace: AWS/Lambda
       MetricName: Duration
       ExtendedStatistic: p99

--- a/infra/aws/opnform-direct-aws-bootstrap.yml
+++ b/infra/aws/opnform-direct-aws-bootstrap.yml
@@ -19,11 +19,17 @@ Resources:
       ThumbprintList:
         - 6938fd4d98bab03faadb97b34396831e3780aea1
         - cabd2a79a1076a31f21d253635cb039d4329a5e8
+      Tags:
+        - Key: Project
+          Value: OpnForm
 
   ServerlessArtifactBucket:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Ref ServerlessArtifactBucketName
+      Tags:
+        - Key: Project
+          Value: OpnForm
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
@@ -49,6 +55,9 @@ Resources:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Ref UiShadowArtifactBucketName
+      Tags:
+        - Key: Project
+          Value: OpnForm
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
@@ -70,6 +79,9 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       RoleName: OpnFormCloudFormationExecutionRole
+      Tags:
+        - Key: Project
+          Value: OpnForm
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -122,13 +134,15 @@ Resources:
                 Effect: Allow
                 Action:
                   - lambda:CreateEventSourceMapping
-                  - lambda:TagResource
                 Resource: !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:event-source-mapping:*'
               - Sid: ManageProductionEventSourceMappings
                 Effect: Allow
                 Action:
                   - lambda:DeleteEventSourceMapping
                   - lambda:GetEventSourceMapping
+                  - lambda:ListTags
+                  - lambda:TagResource
+                  - lambda:UntagResource
                   - lambda:UpdateEventSourceMapping
                 Resource: !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:event-source-mapping:*'
               - Sid: ListProductionEventSourceMappings
@@ -155,6 +169,7 @@ Resources:
                 Action:
                   - events:DeleteRule
                   - events:DescribeRule
+                  - events:ListTagsForResource
                   - events:ListTargetsByRule
                   - events:PutRule
                   - events:PutTargets
@@ -170,6 +185,7 @@ Resources:
                 Effect: Allow
                 Action:
                   - logs:DeleteLogGroup
+                  - logs:ListTagsForResource
                   - logs:PutRetentionPolicy
                   - logs:TagResource
                   - logs:UntagResource
@@ -202,6 +218,7 @@ Resources:
                   - apigateway:POST
                   - apigateway:PUT
                   - apigateway:TagResource
+                  - apigateway:UntagResource
                 Resource: '*'
               - Sid: ReadUiShadowArtifacts
                 Effect: Allow
@@ -224,11 +241,15 @@ Resources:
                   - s3:GetBucketLocation
                   - s3:GetBucketPolicy
                   - s3:GetBucketPublicAccessBlock
+                  - s3:GetBucketTagging
+                  - s3:ListTagsForResource
                   - s3:PutEncryptionConfiguration
                   - s3:PutBucketOwnershipControls
                   - s3:PutBucketPolicy
                   - s3:PutBucketPublicAccessBlock
                   - s3:PutBucketTagging
+                  - s3:TagResource
+                  - s3:UntagResource
                 Resource: arn:aws:s3:::opnform-ui-shadow-*-assets
               - Sid: ManageUiShadowFunctions
                 Effect: Allow
@@ -254,6 +275,7 @@ Resources:
                 Action:
                   - logs:CreateLogGroup
                   - logs:DeleteLogGroup
+                  - logs:ListTagsForResource
                   - logs:PutRetentionPolicy
                   - logs:TagResource
                   - logs:UntagResource
@@ -311,13 +333,20 @@ Resources:
                 Effect: Allow
                 Action:
                   - cloudwatch:DeleteAlarms
+                  - cloudwatch:DescribeAlarms
+                  - cloudwatch:ListTagsForResource
                   - cloudwatch:PutMetricAlarm
+                  - cloudwatch:TagResource
+                  - cloudwatch:UntagResource
                 Resource: !Sub 'arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:opnform-ui-shadow-*'
 
   OpnFormGitHubDeployRole:
     Type: AWS::IAM::Role
     Properties:
       RoleName: OpnFormGitHubDeployRole
+      Tags:
+        - Key: Project
+          Value: OpnForm
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:


### PR DESCRIPTION
## Summary
- add the exact `Project=OpnForm` cost-allocation tag to the direct-AWS bootstrap, Serverless API stack/resources, and supported UI-shadow resources
- preserve existing tags and explicitly keep unsupported resource types untagged
- add fail-closed structural guards plus the narrow CloudFormation handler permissions required to read/update tags on the existing OpnForm resource boundaries

## Verification
- `python3 .github/scripts/check-direct-aws-deploy.py`
- `python3 client/infra/aws/check-ui-shadow.py --self-test`
- `python3 .github/scripts/check-fork-deploy-boundaries.py`
- Python YAML parse of all changed YAML/workflow files
- `aws cloudformation validate-template` for both CloudFormation templates
- `python3 -m py_compile ...`
- `git diff --check`

Live stack change sets, execution, tag backfill/readback, Billing activation, and post-change smoke remain gated on review and CI under Paperclip LAZ-41.