### PR TITLE
fix: use Laravel SQS connector on Bref

### DIFF
--- a/api/app/Providers/AppServiceProvider.php
+++ b/api/app/Providers/AppServiceProvider.php
@@ -4,6 +4,8 @@ namespace App\Providers;
 
 use App\Models\Billing\Subscription;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Queue\Connectors\SqsConnector;
+use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\URL;
@@ -24,6 +26,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        Queue::extend('sqs', fn () => new SqsConnector());
+
         if (config('filesystems.default') === 'local') {
             Storage::disk('local')->buildTemporaryUrlsUsing(function ($path, $expiration, $options) {
                 return URL::temporarySignedRoute(

--- a/api/tests/Feature/Queue/SqsSessionTokenConnectorTest.php
+++ b/api/tests/Feature/Queue/SqsSessionTokenConnectorTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Queue\SqsQueue;
+use Illuminate\Support\Facades\Queue;
+use Laravel\Vapor\Queue\VaporQueue;
+
+it('resolves an SQS connection with temporary credentials through Illuminate', function () {
+    config()->set('queue.connections.session-token-sqs', [
+        'driver' => 'sqs',
+        'key' => 'temporary-access-key',
+        'secret' => 'temporary-secret-key',
+        'token' => 'temporary-session-token',
+        'prefix' => 'https://sqs.us-east-1.amazonaws.com',
+        'queue' => 'form-submissions',
+        'region' => 'us-east-1',
+    ]);
+
+    $connection = Queue::connection('session-token-sqs');
+
+    expect($connection)
+        ->toBeInstanceOf(SqsQueue::class)
+        ->not->toBeInstanceOf(VaporQueue::class);
+});


### PR DESCRIPTION
## Summary
- restore Laravel’s standard SQS connector after Vapor package registration
- preserve Bref temporary-session credentials without passing a raw top-level `token` to AWS SDK
- add a regression test that reproduces the production failure with temporary credentials

## Root cause
Bref injects the Lambda session credential into queue config. Vapor Core overrides Laravel’s SQS connector and leaves that raw value at the AWS client’s top level, which AWS SDK rejects before the form-submission job reaches SQS. Laravel’s connector moves the value into `credentials` and removes the incompatible top-level field.

## Evidence
- RED: focused Pest test failed with `Invalid configuration value provided for "token"`
- GREEN: focused test passes (2 assertions)
- broader API slice: 27 tests, 43 assertions pass
- Pint PSR-12 and PHP syntax pass
- direct-AWS boundary gate passes
- public safety staged-index scan passes against exact clean-main baseline with zero new findings

## Scope
Two files only. No dependencies, IaC, deployment workflow, form data, queue resources, or signed-storage behavior changed.
