### PR TITLE
perf: enable CloudFront response compression

### DIFF
--- a/client/infra/aws/check-ui-shadow.py
+++ b/client/infra/aws/check-ui-shadow.py
@@ -230,7 +230,16 @@ def validate(sources: dict[str, str]) -> list[str]:
         failures.append("template: icon SSR route must precede broad API route")
 
     config = distribution_properties.get("DistributionConfig", {}) if isinstance(distribution_properties, dict) else {}
+    default_cache_behavior = config.get("DefaultCacheBehavior", {}) if isinstance(config, dict) else {}
     cache_behaviors = config.get("CacheBehaviors", []) if isinstance(config, dict) else []
+    if not isinstance(default_cache_behavior, dict) or default_cache_behavior.get("Compress") != "true":
+        failures.append("template: default cache behavior must enable compression")
+    if not isinstance(cache_behaviors, list):
+        failures.append("template: cache behaviors must be a list")
+        cache_behaviors = []
+    for behavior in cache_behaviors:
+        if not isinstance(behavior, dict) or behavior.get("Compress") != "true":
+            failures.append("template: every cache behavior must enable compression")
     behavior_by_path = {behavior.get("PathPattern"): behavior for behavior in cache_behaviors if isinstance(behavior, dict)}
     expected_routes = {"/api/_nuxt_icon/*": "nuxt-ssr", "/api/*": "laravel-api", "/open/*": "laravel-api", "/local/temp/*": "laravel-api", "/_nuxt/*": "private-public-assets"}
     for path, origin in expected_routes.items():
@@ -244,14 +253,14 @@ def validate(sources: dict[str, str]) -> list[str]:
     if any(no_shared.get(key) != "0" for key in ("DefaultTTL", "MaxTTL", "MinTTL")):
         failures.append("template: zero-cache policy TTLs changed")
     expected_no_shared_parameters = {
-        "EnableAcceptEncodingBrotli": "false",
-        "EnableAcceptEncodingGzip": "false",
+        "EnableAcceptEncodingBrotli": "true",
+        "EnableAcceptEncodingGzip": "true",
         "CookiesConfig": {"CookieBehavior": "none"},
         "HeadersConfig": {"HeaderBehavior": "none"},
         "QueryStringsConfig": {"QueryStringBehavior": "none"},
     }
     if no_shared.get("ParametersInCacheKeyAndForwardedToOrigin") != expected_no_shared_parameters:
-        failures.append("template: zero-cache policy must disable compressed encoding and cache keys")
+        failures.append("template: zero-cache policy must enable compressed encoding without shared caching")
     expected_origin_request_policy = {
         "Name": "${ShadowPrefix}-all-viewer-no-host",
         "CookiesConfig": {"CookieBehavior": "all"},
@@ -540,7 +549,9 @@ def self_test(sources: dict[str, str]) -> list[str]:
         ("template", "DefaultTTL: 0", "DefaultTTL: 3600"),
         ("template", "DefaultTTL: 31536000", "DefaultTTL: 0"),
         ("template", "MemorySize: 2048", "MemorySize: 4096"),
-        ("template", "EnableAcceptEncodingGzip: false", "EnableAcceptEncodingGzip: true"),
+        ("template", "EnableAcceptEncodingGzip: true", "EnableAcceptEncodingGzip: false"),
+        ("template", "DefaultCacheBehavior:\n          TargetOriginId: nuxt-ssr\n          ViewerProtocolPolicy: redirect-to-https\n          AllowedMethods: [GET, HEAD, OPTIONS, PUT, PATCH, POST, DELETE]\n          CachedMethods: [GET, HEAD]\n          Compress: true", "DefaultCacheBehavior:\n          TargetOriginId: nuxt-ssr\n          ViewerProtocolPolicy: redirect-to-https\n          AllowedMethods: [GET, HEAD, OPTIONS, PUT, PATCH, POST, DELETE]\n          CachedMethods: [GET, HEAD]\n          Compress: false"),
+        ("template", "PathPattern: /llms.txt\n            TargetOriginId: private-public-assets\n            ViewerProtocolPolicy: redirect-to-https\n            AllowedMethods: [GET, HEAD, OPTIONS]\n            CachedMethods: [GET, HEAD]\n            Compress: true", "PathPattern: /llms.txt\n            TargetOriginId: private-public-assets\n            ViewerProtocolPolicy: redirect-to-https\n            AllowedMethods: [GET, HEAD, OPTIONS]\n            CachedMethods: [GET, HEAD]\n            Compress: false"),
         ("template", "HeaderBehavior: allExcept", "HeaderBehavior: allViewerExceptHostHeader"),
         ("template", "            - host", "            - authorization"),
         ("template", "${ShadowPrefix}-viewer-rewrite", "${ShadowPrefix}-viewer-host-and-api-rewrite"),

--- a/client/infra/aws/ui-shadow.yml
+++ b/client/infra/aws/ui-shadow.yml
@@ -141,8 +141,8 @@ Resources:
         MaxTTL: 0
         MinTTL: 0
         ParametersInCacheKeyAndForwardedToOrigin:
-          EnableAcceptEncodingBrotli: false
-          EnableAcceptEncodingGzip: false
+          EnableAcceptEncodingBrotli: true
+          EnableAcceptEncodingGzip: true
           CookiesConfig:
             CookieBehavior: none
           HeadersConfig:
@@ -240,6 +240,7 @@ Resources:
           ViewerProtocolPolicy: redirect-to-https
           AllowedMethods: [GET, HEAD, OPTIONS, PUT, PATCH, POST, DELETE]
           CachedMethods: [GET, HEAD]
+          Compress: true
           CachePolicyId: !Ref NoSharedCachePolicy
           OriginRequestPolicyId: !Ref AllViewerOriginRequestPolicy
           FunctionAssociations:
@@ -252,6 +253,7 @@ Resources:
             ViewerProtocolPolicy: redirect-to-https
             AllowedMethods: [GET, HEAD, OPTIONS, PUT, PATCH, POST, DELETE]
             CachedMethods: [GET, HEAD]
+            Compress: true
             CachePolicyId: !Ref NoSharedCachePolicy
             OriginRequestPolicyId: !Ref AllViewerOriginRequestPolicy
             FunctionAssociations:
@@ -262,6 +264,7 @@ Resources:
             ViewerProtocolPolicy: https-only
             AllowedMethods: [GET, HEAD, OPTIONS, PUT, PATCH, POST, DELETE]
             CachedMethods: [GET, HEAD]
+            Compress: true
             CachePolicyId: !Ref NoSharedCachePolicy
             OriginRequestPolicyId: !Ref AllViewerOriginRequestPolicy
             FunctionAssociations:
@@ -272,6 +275,7 @@ Resources:
             ViewerProtocolPolicy: https-only
             AllowedMethods: [GET, HEAD, OPTIONS, PUT, PATCH, POST, DELETE]
             CachedMethods: [GET, HEAD]
+            Compress: true
             CachePolicyId: !Ref NoSharedCachePolicy
             OriginRequestPolicyId: !Ref AllViewerOriginRequestPolicy
             FunctionAssociations:
@@ -282,6 +286,7 @@ Resources:
             ViewerProtocolPolicy: https-only
             AllowedMethods: [GET, HEAD, OPTIONS, PUT, PATCH, POST, DELETE]
             CachedMethods: [GET, HEAD]
+            Compress: true
             CachePolicyId: !Ref NoSharedCachePolicy
             OriginRequestPolicyId: !Ref AllViewerOriginRequestPolicy
             FunctionAssociations:
@@ -292,54 +297,63 @@ Resources:
             ViewerProtocolPolicy: redirect-to-https
             AllowedMethods: [GET, HEAD, OPTIONS]
             CachedMethods: [GET, HEAD]
+            Compress: true
             CachePolicyId: !Ref ImmutableNuxtAssetCachePolicy
           - PathPattern: /icons/*
             TargetOriginId: private-public-assets
             ViewerProtocolPolicy: redirect-to-https
             AllowedMethods: [GET, HEAD, OPTIONS]
             CachedMethods: [GET, HEAD]
+            Compress: true
             CachePolicyId: !Ref NoSharedCachePolicy
           - PathPattern: /fonts/*
             TargetOriginId: private-public-assets
             ViewerProtocolPolicy: redirect-to-https
             AllowedMethods: [GET, HEAD, OPTIONS]
             CachedMethods: [GET, HEAD]
+            Compress: true
             CachePolicyId: !Ref NoSharedCachePolicy
           - PathPattern: /widgets/*
             TargetOriginId: private-public-assets
             ViewerProtocolPolicy: redirect-to-https
             AllowedMethods: [GET, HEAD, OPTIONS]
             CachedMethods: [GET, HEAD]
+            Compress: true
             CachePolicyId: !Ref NoSharedCachePolicy
           - PathPattern: /video/*
             TargetOriginId: private-public-assets
             ViewerProtocolPolicy: redirect-to-https
             AllowedMethods: [GET, HEAD, OPTIONS]
             CachedMethods: [GET, HEAD]
+            Compress: true
             CachePolicyId: !Ref NoSharedCachePolicy
           - PathPattern: /img/*
             TargetOriginId: private-public-assets
             ViewerProtocolPolicy: redirect-to-https
             AllowedMethods: [GET, HEAD, OPTIONS]
             CachedMethods: [GET, HEAD]
+            Compress: true
             CachePolicyId: !Ref NoSharedCachePolicy
           - PathPattern: /favicon.ico
             TargetOriginId: private-public-assets
             ViewerProtocolPolicy: redirect-to-https
             AllowedMethods: [GET, HEAD, OPTIONS]
             CachedMethods: [GET, HEAD]
+            Compress: true
             CachePolicyId: !Ref NoSharedCachePolicy
           - PathPattern: /robots.txt
             TargetOriginId: private-public-assets
             ViewerProtocolPolicy: redirect-to-https
             AllowedMethods: [GET, HEAD, OPTIONS]
             CachedMethods: [GET, HEAD]
+            Compress: true
             CachePolicyId: !Ref NoSharedCachePolicy
           - PathPattern: /llms.txt
             TargetOriginId: private-public-assets
             ViewerProtocolPolicy: redirect-to-https
             AllowedMethods: [GET, HEAD, OPTIONS]
             CachedMethods: [GET, HEAD]
+            Compress: true
             CachePolicyId: !Ref NoSharedCachePolicy
       Tags:
         - Key: Project


### PR DESCRIPTION
## Problem
The direct-AWS OpnForm CloudFront distribution has compression disabled. The Austin public form document is about 347 KB uncompressed; local gzip measurement is about 52.6 KB, an 84.8% reduction. Shared caching remains intentionally disabled because public form responses set cookies and may vary by request state.

## Change
- enable Brotli/gzip encoding negotiation on `NoSharedCachePolicy`
- set `Compress: true` on the default behavior and every explicit cache behavior
- keep all zero-cache TTLs, origins, methods, route order, and auth forwarding unchanged
- strengthen `check-ui-shadow.py` and its adversarial self-tests to reject disabled compression

## Verification
- `python3 client/infra/aws/check-ui-shadow.py`
- `git diff --check`

## Protected boundaries
- no shared-cache TTL added
- no form/API/auth code changed
- no origin, domain, route, or provisioned-concurrency change
- direct AWS runtime and authenticated/submission behavior remain unchanged
