### PR TITLE
OpnForm: trim anonymous public-form SSR bootstrap

### DIFF
--- a/client/plugins/feature-flags.server.js
+++ b/client/plugins/feature-flags.server.js
@@ -1,15 +1,24 @@
 import { contentApi } from '~/api/content'
 
+function isPlainObject(value) {
+  if (value === null || typeof value !== 'object') {
+    return false
+  }
+
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
 export default defineNuxtPlugin(async (nuxtApp) => {
   // Load feature flags during SSR using cached server route
   const featureFlagsState = useState('featureFlags', () => ({}))
   
   try {
-    const flags = await contentApi.featureFlags.list({ server: true })
-    featureFlagsState.value = flags
+    const flags = await $fetch('/api/feature-flags')
+    featureFlagsState.value = isPlainObject(flags) ? flags : {}
   } catch (error) {
     console.error('Failed to load feature flags on server:', error)
-    // Keep empty object as fallback
+    featureFlagsState.value = {}
   }
 
   // Provide simple refresh capability

--- a/client/plugins/plan-catalog.server.js
+++ b/client/plugins/plan-catalog.server.js
@@ -3,13 +3,19 @@ import { contentApi } from '~/api/content'
 export default defineNuxtPlugin(async (nuxtApp) => {
   const planCatalogState = useState('planCatalog', () => ({ tiers: {} }))
 
-  try {
-    const plans = await contentApi.plans.list({ server: true })
-    if (plans?.tiers) {
-      planCatalogState.value = plans
+  const route = useRoute()
+  const { isAuthenticated } = useIsAuthenticated()
+  const shouldLoadPlanCatalog = route.name !== 'forms-slug' || isAuthenticated.value
+
+  if (shouldLoadPlanCatalog) {
+    try {
+      const plans = await contentApi.plans.list({ server: true })
+      if (plans?.tiers) {
+        planCatalogState.value = plans
+      }
+    } catch (error) {
+      console.error('Failed to load plan catalog on server:', error)
     }
-  } catch (error) {
-    console.error('Failed to load plan catalog on server:', error)
   }
 
   nuxtApp.provide('refreshPlanCatalog', async () => {

--- a/client/test/unit/ssr-bootstrap.test.ts
+++ b/client/test/unit/ssr-bootstrap.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { featureFlagsList, plansList } = vi.hoisted(() => ({
+  featureFlagsList: vi.fn(),
+  plansList: vi.fn(),
+}))
+
+vi.mock('~/api/content', () => ({
+  contentApi: {
+    featureFlags: { list: featureFlagsList },
+    plans: { list: plansList },
+  },
+}))
+
+function setupPluginState() {
+  const state = { value: undefined }
+
+  globalThis.defineNuxtPlugin = (plugin) => plugin
+  globalThis.useState = vi.fn((key, initialValue) => {
+    if (state.value === undefined) {
+      state.value = initialValue()
+    }
+    return state
+  })
+
+  return state
+}
+
+async function loadPlanCatalogPlugin(routeName, isAuthenticated) {
+  const state = setupPluginState()
+  globalThis.useRoute = () => ({ name: routeName })
+  globalThis.useIsAuthenticated = () => ({
+    isAuthenticated: { value: isAuthenticated },
+  })
+
+  const { default: plugin } = await import('../../plugins/plan-catalog.server.js')
+  return { plugin, state }
+}
+
+async function loadFeatureFlagsPlugin() {
+  const state = setupPluginState()
+  const { default: plugin } = await import('../../plugins/feature-flags.server.js')
+  return { plugin, state }
+}
+
+describe('SSR bootstrap plugins', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  it('skips plan loading for anonymous public forms and installs refreshPlanCatalog', async () => {
+    const { plugin, state } = await loadPlanCatalogPlugin('forms-slug', false)
+    const nuxtApp = { provide: vi.fn() }
+
+    await plugin(nuxtApp)
+
+    expect(plansList).not.toHaveBeenCalled()
+    expect(state.value).toEqual({ tiers: {} })
+    expect(nuxtApp.provide).toHaveBeenCalledWith('refreshPlanCatalog', expect.any(Function))
+  })
+
+  it('loads plans for authenticated public forms', async () => {
+    plansList.mockResolvedValue({ tiers: { pro: {} } })
+    const { plugin } = await loadPlanCatalogPlugin('forms-slug', true)
+
+    await plugin({ provide: vi.fn() })
+
+    expect(plansList).toHaveBeenCalledWith({ server: true })
+  })
+
+  it('loads plans for anonymous non-public routes', async () => {
+    plansList.mockResolvedValue({ tiers: { pro: {} } })
+    const { plugin } = await loadPlanCatalogPlugin('dashboard', false)
+
+    await plugin({ provide: vi.fn() })
+
+    expect(plansList).toHaveBeenCalledWith({ server: true })
+  })
+
+  it('loads valid feature flags from the cached Nitro endpoint', async () => {
+    const flags = { payments: true }
+    globalThis.$fetch = vi.fn().mockResolvedValue(flags)
+    const { plugin, state } = await loadFeatureFlagsPlugin()
+
+    await plugin({ provide: vi.fn() })
+
+    expect(globalThis.$fetch).toHaveBeenCalledWith('/api/feature-flags')
+    expect(featureFlagsList).not.toHaveBeenCalled()
+    expect(state.value).toEqual(flags)
+  })
+
+  it.each([null, []])('falls back to empty feature flags for invalid response %j', async (response) => {
+    globalThis.$fetch = vi.fn().mockResolvedValue(response)
+    const { plugin, state } = await loadFeatureFlagsPlugin()
+
+    await plugin({ provide: vi.fn() })
+
+    expect(state.value).toEqual({})
+  })
+
+  it('falls back to empty feature flags when the cached endpoint rejects', async () => {
+    globalThis.$fetch = vi.fn().mockRejectedValue(new Error('Failed'))
+    const { plugin, state } = await loadFeatureFlagsPlugin()
+
+    await plugin({ provide: vi.fn() })
+
+    expect(state.value).toEqual({})
+  })
+})


### PR DESCRIPTION
## Summary
- skip the initial plan-catalog SSR request only for anonymous `forms-slug` renders
- load initial SSR feature flags through the existing cached Nitro `/api/feature-flags` endpoint with an explicit `{}` fallback
- preserve authenticated/non-public plan loading and all refresh providers

## Safety boundary
- no HTML/route caching or route rules
- no cookie, session, auth, `form-password`, submission, upload, payment, API, schema, infrastructure, or IAM changes
- public form data still renders through its existing uncached SSR/API path

## Verification
- `npm run test -- --run test/unit/ssr-bootstrap.test.ts` — 7 passed
- `npm run test -- --run --project unit` — 30 files / 476 tests passed (existing Vue inject warnings only)
- `npx eslint plugins/plan-catalog.server.js plugins/feature-flags.server.js test/unit/ssr-bootstrap.test.ts` — 0 errors; test TypeScript is outside the repository ESLint config and reported one ignore warning
- `git diff --check` — passed
- local `npm run build:aws-lambda` reached completed Vite client/server build twice but the Nitro packaging tail exceeded the 600-second local command ceiling; exact-head CI is required before merge

## Baseline
Five canonical browser-like anonymous form documents: TTFB 4.570811, 1.924079, 1.954639, 1.845927, 1.843256 seconds; median 1.924079 seconds; every response HTTP 200 and `x-cache: Miss from cloudfront` with response cookie present.

Paperclip: LAZ-90
