### PR TITLE
OpnForm: keep zero-TTL cache policy deployable

### DIFF
--- a/client/infra/aws/check-ui-shadow.py
+++ b/client/infra/aws/check-ui-shadow.py
@@ -253,14 +253,14 @@ def validate(sources: dict[str, str]) -> list[str]:
     if any(no_shared.get(key) != "0" for key in ("DefaultTTL", "MaxTTL", "MinTTL")):
         failures.append("template: zero-cache policy TTLs changed")
     expected_no_shared_parameters = {
-        "EnableAcceptEncodingBrotli": "true",
-        "EnableAcceptEncodingGzip": "true",
+        "EnableAcceptEncodingBrotli": "false",
+        "EnableAcceptEncodingGzip": "false",
         "CookiesConfig": {"CookieBehavior": "none"},
         "HeadersConfig": {"HeaderBehavior": "none"},
         "QueryStringsConfig": {"QueryStringBehavior": "none"},
     }
     if no_shared.get("ParametersInCacheKeyAndForwardedToOrigin") != expected_no_shared_parameters:
-        failures.append("template: zero-cache policy must enable compressed encoding without shared caching")
+        failures.append("template: zero-cache policy must not vary its disabled cache key by compressed encoding")
     expected_origin_request_policy = {
         "Name": "${ShadowPrefix}-all-viewer-no-host",
         "CookiesConfig": {"CookieBehavior": "all"},
@@ -549,7 +549,7 @@ def self_test(sources: dict[str, str]) -> list[str]:
         ("template", "DefaultTTL: 0", "DefaultTTL: 3600"),
         ("template", "DefaultTTL: 31536000", "DefaultTTL: 0"),
         ("template", "MemorySize: 2048", "MemorySize: 4096"),
-        ("template", "EnableAcceptEncodingGzip: true", "EnableAcceptEncodingGzip: false"),
+        ("template", "EnableAcceptEncodingGzip: false", "EnableAcceptEncodingGzip: true"),
         ("template", "DefaultCacheBehavior:\n          TargetOriginId: nuxt-ssr\n          ViewerProtocolPolicy: redirect-to-https\n          AllowedMethods: [GET, HEAD, OPTIONS, PUT, PATCH, POST, DELETE]\n          CachedMethods: [GET, HEAD]\n          Compress: true", "DefaultCacheBehavior:\n          TargetOriginId: nuxt-ssr\n          ViewerProtocolPolicy: redirect-to-https\n          AllowedMethods: [GET, HEAD, OPTIONS, PUT, PATCH, POST, DELETE]\n          CachedMethods: [GET, HEAD]\n          Compress: false"),
         ("template", "PathPattern: /llms.txt\n            TargetOriginId: private-public-assets\n            ViewerProtocolPolicy: redirect-to-https\n            AllowedMethods: [GET, HEAD, OPTIONS]\n            CachedMethods: [GET, HEAD]\n            Compress: true", "PathPattern: /llms.txt\n            TargetOriginId: private-public-assets\n            ViewerProtocolPolicy: redirect-to-https\n            AllowedMethods: [GET, HEAD, OPTIONS]\n            CachedMethods: [GET, HEAD]\n            Compress: false"),
         ("template", "HeaderBehavior: allExcept", "HeaderBehavior: allViewerExceptHostHeader"),

--- a/client/infra/aws/ui-shadow.yml
+++ b/client/infra/aws/ui-shadow.yml
@@ -141,8 +141,8 @@ Resources:
         MaxTTL: 0
         MinTTL: 0
         ParametersInCacheKeyAndForwardedToOrigin:
-          EnableAcceptEncodingBrotli: true
-          EnableAcceptEncodingGzip: true
+          EnableAcceptEncodingBrotli: false
+          EnableAcceptEncodingGzip: false
           CookiesConfig:
             CookieBehavior: none
           HeadersConfig:


### PR DESCRIPTION
## Summary
- correct the zero-TTL HTML cache policy so CloudFront does not reject it when response compression is enabled on the behavior
- keep `Compress: true` on the CloudFront behavior while removing compressed-encoding variation from a policy whose TTL is always zero
- update the structural validator and mutation self-test to lock this requirement

## Failure evidence
The approved main validation UI deployment rolled back because `NoSharedCachePolicy` combined `DefaultTTL/MinTTL/MaxTTL: 0` with `EnableAcceptEncodingBrotli/Gzip: true`; CloudFormation returned `Invalid request provided: AWS::CloudFront::CachePolicy`. The failed run is https://github.com/TotalLag/OpnForm/actions/runs/30843074324 and diagnostic evidence is https://github.com/TotalLag/OpnForm/actions/runs/30843443138.

## Safety boundary
- no HTML shared caching; all HTML TTLs remain zero
- no cookie, header, query, origin-request, auth, session, `form-password`, API, data, IAM, DNS, or hostname changes
- immutable `/_nuxt/*` cache policy remains compression-keyed and unchanged

## Verification
- `python3 client/infra/aws/check-ui-shadow.py` — passed
- `cfn-lint client/infra/aws/ui-shadow.yml` — passed
- `git diff --check` — passed
- `cd client && npm run test -- --run test/unit/ssr-bootstrap.test.ts` — 7 passed

Paperclip: LAZ-90 focused corrective loop